### PR TITLE
Add native SetEnv configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,8 @@ defaults:
   * a `defaults` section containing global flags
   * and an `includes` section containing path to other configuration files
 
+SSH options such as `SetEnv` can be placed under `defaults`; `assh config build` writes them into the generated `~/.ssh/config`.
+
 ```yaml
 hosts:
 
@@ -489,6 +491,8 @@ templates:
 
 defaults:
   # Defaults are applied to each hosts
+  SetEnv:
+  - TERM=xterm-256color
   ControlMaster: auto
   ControlPath: ~/tmp/.ssh/cm/%h-%p-%r.sock
   ControlPersist: yes

--- a/docs/superpowers/plans/2026-08-19-native-setenv-config.md
+++ b/docs/superpowers/plans/2026-08-19-native-setenv-config.md
@@ -1,0 +1,40 @@
+# Native SetEnv Configuration Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow `SetEnv` in `~/.assh.yml`, including under `defaults`, to be parsed, inherited by hosts, and emitted by `assh config build` as an OpenSSH `SetEnv` directive.
+
+**Architecture:** Extend `pkg/config.Host` with the same `composeyaml.Stringorslice` representation used by `SendEnv`. Thread the field through option listing, default application/environment expansion, and SSH config generation so the native build path handles it without hooks. Keep hook execution and command behavior unchanged, and verify the full path with focused model and configuration tests.
+
+**Tech Stack:** Go 1.14, `flexyaml`, `composeyaml.Stringorslice`, GoConvey, `gofmt`, `go test`.
+
+---
+
+## Implementation Tasks
+
+- [x] Add failing coverage for native `SetEnv` support.
+  - In `pkg/config/host_test.go`, extend the default-application coverage to assert that a host with no explicit `SetEnv` receives the defaults value.
+  - Add focused assertions that `Host.Options()` exposes each `SetEnv` entry and that `Host.WriteSSHConfigTo` emits `SetEnv TERM=xterm-256color`.
+  - In `pkg/config/config_test.go`, load YAML containing `defaults.SetEnv`, resolve a host, assert the inherited model value, and assert that `Config.WriteSSHConfigTo` contains the generated global `Host *` directive.
+  - Run `go test ./pkg/config`; these tests should fail before the model/generator implementation exists.
+
+- [x] Add `SetEnv` to the configuration model and generation pipeline.
+  - In `pkg/config/host.go`, add `SetEnv composeyaml.Stringorslice` beside `SendEnv` with YAML key `setenv` and JSON key `SetEnv`.
+  - Add the field to `Host.Options()` using one `Option{Name: "SetEnv", Value: entry}` per entry.
+  - Add the same empty-host fallback and `utils.ExpandSliceField` call used by `SendEnv` in `Host.ApplyDefaults`.
+  - Emit one `SetEnv <value>` line per entry from `Host.WriteSSHConfigTo`.
+  - Do not modify hook execution or `assh config build`; the existing build path will consume the modeled field.
+
+- [x] Document the concise user-facing configuration.
+  - In the main configuration example in `README.md`, show:
+    ```yaml
+    defaults:
+      SetEnv:
+      - TERM=xterm-256color
+    ```
+  - State that this is written into generated `~/.ssh/config` by the normal `assh config build` flow.
+
+- [x] Format, test, and self-review.
+  - Run `gofmt` on the changed Go files.
+  - Run `go test ./pkg/config` and then `go test ./...`.
+  - Review the diff to confirm the change is limited to the model, generation, tests, and documentation; verify no hook behavior or generated-file post-processing was introduced.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1292,6 +1292,39 @@ func TestConfig_String(t *testing.T) {
 	})
 }
 
+func TestConfig_SetEnv(t *testing.T) {
+	Convey("Testing Config.SetEnv", t, func() {
+		config := New()
+		err := config.LoadConfig(strings.NewReader(`
+defaults:
+  SetEnv:
+  - TERM=xterm-256color
+hosts:
+  example:
+    HostName: example.com
+  direct:
+    HostName: direct.example.com
+    SetEnv: LANG=C
+`))
+		So(err, ShouldBeNil)
+
+		host, err := config.GetHost("example")
+		So(err, ShouldBeNil)
+		So([]string(host.SetEnv), ShouldResemble, []string{"TERM=xterm-256color"})
+		So(strings.Contains(config.String(), `"SetEnv":["TERM=xterm-256color"]`), ShouldBeTrue)
+
+		directHost, err := config.GetHost("direct")
+		So(err, ShouldBeNil)
+		So([]string(directHost.SetEnv), ShouldResemble, []string{"LANG=C"})
+
+		var buffer bytes.Buffer
+		err = config.WriteSSHConfigTo(&buffer)
+		So(err, ShouldBeNil)
+		So(strings.Contains(buffer.String(), "Host *\n  SetEnv TERM=xterm-256color\n"), ShouldBeTrue)
+		So(strings.Contains(buffer.String(), "Host direct\n  SetEnv LANG=C\n"), ShouldBeTrue)
+	})
+}
+
 func TestConfig_WriteSSHConfig(t *testing.T) {
 	Convey("Testing Config.WriteSSHConfig", t, func() {
 		config := dummyConfig()

--- a/pkg/config/host.go
+++ b/pkg/config/host.go
@@ -96,6 +96,7 @@ type Host struct {
 	RhostsRSAAuthentication          string                    `yaml:"rhostsrsaauthentication,omitempty,flow" json:"RhostsRSAAuthentication,omitempty"`
 	RSAAuthentication                string                    `yaml:"rsaauthentication,omitempty,flow" json:"RSAAuthentication,omitempty"`
 	SendEnv                          composeyaml.Stringorslice `yaml:"sendenv,omitempty,flow" json:"SendEnv,omitempty"`
+	SetEnv                           composeyaml.Stringorslice `yaml:"setenv,omitempty,flow" json:"SetEnv,omitempty"`
 	ServerAliveCountMax              int                       `yaml:"serveralivecountmax,omitempty,flow" json:"ServerAliveCountMax,omitempty"`
 	ServerAliveInterval              int                       `yaml:"serveraliveinterval,omitempty,flow" json:"ServerAliveInterval,omitempty"`
 	StreamLocalBindMask              string                    `yaml:"streamlocalbindmask,omitempty,flow" json:"StreamLocalBindMask,omitempty"`
@@ -485,6 +486,9 @@ func (h *Host) Options() OptionsList {
 	}
 	for _, entry := range h.SendEnv {
 		options = append(options, Option{Name: "SendEnv", Value: entry})
+	}
+	for _, entry := range h.SetEnv {
+		options = append(options, Option{Name: "SetEnv", Value: entry})
 	}
 	if h.ServerAliveCountMax != 0 {
 		options = append(options, Option{Name: "ServerAliveCountMax", Value: fmt.Sprintf("%d", h.ServerAliveCountMax)})
@@ -994,6 +998,11 @@ func (h *Host) ApplyDefaults(defaults *Host) {
 	}
 	h.SendEnv = utils.ExpandSliceField(h.SendEnv)
 
+	if len(h.SetEnv) == 0 {
+		h.SetEnv = defaults.SetEnv
+	}
+	h.SetEnv = utils.ExpandSliceField(h.SetEnv)
+
 	if h.ServerAliveCountMax == 0 {
 		h.ServerAliveCountMax = defaults.ServerAliveCountMax
 	}
@@ -1408,6 +1417,9 @@ func (h *Host) WriteSSHConfigTo(w io.Writer) error {
 		}
 		for _, entry := range h.SendEnv {
 			_, _ = fmt.Fprintf(w, "  SendEnv %s\n", entry)
+		}
+		for _, entry := range h.SetEnv {
+			_, _ = fmt.Fprintf(w, "  SetEnv %s\n", entry)
 		}
 		if h.ServerAliveCountMax != 0 {
 			_, _ = fmt.Fprintf(w, "  ServerAliveCountMax %d\n", h.ServerAliveCountMax)

--- a/pkg/config/host_test.go
+++ b/pkg/config/host_test.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"os/user"
+	"strings"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -17,8 +19,9 @@ func TestHost_ApplyDefaults(t *testing.T) {
 				User:     "root",
 			}
 			defaults := &Host{
-				User: "bobby",
-				Port: "42",
+				User:   "bobby",
+				Port:   "42",
+				SetEnv: []string{"TERM=xterm-256color"},
 			}
 			host.ApplyDefaults(defaults)
 			So(host.Port, ShouldEqual, "42")
@@ -30,6 +33,7 @@ func TestHost_ApplyDefaults(t *testing.T) {
 			So(len(host.ResolveNameservers), ShouldEqual, 0)
 			So(host.ResolveCommand, ShouldEqual, "")
 			So(host.ControlPath, ShouldEqual, "")
+			So([]string(host.SetEnv), ShouldResemble, []string{"TERM=xterm-256color"})
 		})
 		Convey("Empty configuration", func() {
 			host := &Host{}
@@ -179,6 +183,20 @@ func TestHost_Options(t *testing.T) {
 		options = host.Options()
 		So(len(options), ShouldEqual, 98)
 		So(options, ShouldResemble, OptionsList{{Name: "AddKeysToAgent", Value: "yes"}, {Name: "AddressFamily", Value: "any"}, {Name: "AskPassGUI", Value: "yes"}, {Name: "BatchMode", Value: "no"}, {Name: "CanonicalDomains", Value: "42.am"}, {Name: "CanonicalizeFallbackLocal", Value: "no"}, {Name: "CanonicalizeHostname", Value: "yes"}, {Name: "CanonicalizeMaxDots", Value: "1"}, {Name: "CanonicalizePermittedCNAMEs", Value: "*.a.example.com:*.b.example.com:*.c.example.com"}, {Name: "ChallengeResponseAuthentication", Value: "yes"}, {Name: "CheckHostIP", Value: "yes"}, {Name: "Cipher", Value: "blowfish"}, {Name: "Ciphers", Value: "aes128-ctr,aes192-ctr,aes256-ctr,test"}, {Name: "ClearAllForwardings", Value: "yes"}, {Name: "Compression", Value: "yes"}, {Name: "CompressionLevel", Value: "6"}, {Name: "ConnectionAttempts", Value: "1"}, {Name: "ConnectTimeout", Value: "10"}, {Name: "ControlMaster", Value: "yes"}, {Name: "ControlPath", Value: "/tmp/%L-%l-%n-%p-%u-%r-%C-%h"}, {Name: "ControlPersist", Value: "yes"}, {Name: "DynamicForward", Value: "0.0.0.0:4242"}, {Name: "DynamicForward", Value: "0.0.0.0:4343"}, {Name: "EnableSSHKeysign", Value: "yes"}, {Name: "EscapeChar", Value: "~"}, {Name: "ExitOnForwardFailure", Value: "yes"}, {Name: "FingerprintHash", Value: "sha256"}, {Name: "ForwardAgent", Value: "yes"}, {Name: "ForwardX11", Value: "yes"}, {Name: "ForwardX11Timeout", Value: "42"}, {Name: "ForwardX11Trusted", Value: "yes"}, {Name: "GatewayPorts", Value: "yes"}, {Name: "GlobalKnownHostsFile", Value: "/etc/ssh/ssh_known_hosts /tmp/ssh_known_hosts"}, {Name: "GSSAPIAuthentication", Value: "no"}, {Name: "GSSAPIClientIdentity", Value: "moul"}, {Name: "GSSAPIDelegateCredentials", Value: "no"}, {Name: "GSSAPIKeyExchange", Value: "no"}, {Name: "GSSAPIRenewalForcesRekey", Value: "no"}, {Name: "GSSAPIServerIdentity", Value: "gssapi.example.com"}, {Name: "GSSAPITrustDNS", Value: "no"}, {Name: "HashKnownHosts", Value: "no"}, {Name: "HostbasedAuthentication", Value: "no"}, {Name: "HostbasedKeyTypes", Value: "*"}, {Name: "HostKeyAlgorithms", Value: "ecdsa-sha2-nistp256-cert-v01@openssh.com,test"}, {Name: "HostKeyAlias", Value: "z"}, {Name: "IdentitiesOnly", Value: "yes"}, {Name: "IdentityFile", Value: "~/.ssh/identity"}, {Name: "IdentityFile", Value: "~/.ssh/identity2"}, {Name: "IgnoreUnknown", Value: "testtest"}, {Name: "IPQoS", Value: "lowdelay highdelay"}, {Name: "KbdInteractiveAuthentication", Value: "yes"}, {Name: "KbdInteractiveDevices", Value: "bsdauth,test"}, {Name: "KexAlgorithms", Value: "curve25519-sha256@libssh.org,test"}, {Name: "KeychainIntegration", Value: "yes"}, {Name: "LocalCommand", Value: "echo %h > /tmp/logs"}, {Name: "RemoteCommand", Value: "echo %h > /tmp/logs"}, {Name: "LocalForward", Value: "0.0.0.0:1234"}, {Name: "LocalForward", Value: "0.0.0.0:1235"}, {Name: "LogLevel", Value: "DEBUG3"}, {Name: "MACs", Value: "umac-64-etm@openssh.com,umac-128-etm@openssh.com,test"}, {Name: "Match", Value: "all"}, {Name: "NoHostAuthenticationForLocalhost", Value: "yes"}, {Name: "NumberOfPasswordPrompts", Value: "3"}, {Name: "PasswordAuthentication", Value: "yes"}, {Name: "PermitLocalCommand", Value: "yes"}, {Name: "PKCS11Provider", Value: "/a/b/c/pkcs11.so"}, {Name: "Port", Value: "22"}, {Name: "PreferredAuthentications", Value: "gssapi-with-mic,hostbased,publickey"}, {Name: "Protocol", Value: "2,3"}, {Name: "ProxyJump", Value: "proxy.host"}, {Name: "ProxyUseFdpass", Value: "no"}, {Name: "PubkeyAcceptedAlgorithms", Value: "+ssh-rsa"}, {Name: "PubkeyAcceptedKeyTypes", Value: "+ssh-dss"}, {Name: "PubkeyAuthentication", Value: "yes"}, {Name: "RekeyLimit", Value: "default none"}, {Name: "RemoteForward", Value: "0.0.0.0:1234"}, {Name: "RemoteForward", Value: "0.0.0.0:1235"}, {Name: "RequestTTY", Value: "yes"}, {Name: "RevokedHostKeys", Value: "/a/revoked-keys"}, {Name: "RhostsRSAAuthentication", Value: "no"}, {Name: "RSAAuthentication", Value: "yes"}, {Name: "SendEnv", Value: "CUSTOM_*,TEST"}, {Name: "SendEnv", Value: "TEST2"}, {Name: "ServerAliveCountMax", Value: "3"}, {Name: "StreamLocalBindMask", Value: "0177"}, {Name: "StreamLocalBindUnlink", Value: "no"}, {Name: "StrictHostKeyChecking", Value: "ask"}, {Name: "TCPKeepAlive", Value: "yes"}, {Name: "Tunnel", Value: "yes"}, {Name: "TunnelDevice", Value: "any:any"}, {Name: "UpdateHostKeys", Value: "ask"}, {Name: "UseKeychain", Value: "no"}, {Name: "UsePrivilegedPort", Value: "no"}, {Name: "User", Value: "moul"}, {Name: "UserKnownHostsFile", Value: "~/.ssh/known_hosts ~/.ssh/known_hosts2 /tmp/known_hosts"}, {Name: "VerifyHostKeyDNS", Value: "no"}, {Name: "VisualHostKey", Value: "yes"}, {Name: "XAuthLocation", Value: "xauth"}})
+	})
+}
+
+func TestHost_SetEnv(t *testing.T) {
+	Convey("Testing Host.SetEnv", t, func() {
+		host := NewHost("example")
+		host.SetEnv = []string{"TERM=xterm-256color"}
+
+		So(host.Options(), ShouldResemble, OptionsList{{Name: "SetEnv", Value: "TERM=xterm-256color"}})
+
+		var buffer bytes.Buffer
+		err := host.WriteSSHConfigTo(&buffer)
+		So(err, ShouldBeNil)
+		So(strings.Contains(buffer.String(), "  SetEnv TERM=xterm-256color\n"), ShouldBeTrue)
 	})
 }
 


### PR DESCRIPTION
## Summary

- Add SetEnv to the configuration model with defaults inheritance and JSON output.
- Emit native OpenSSH SetEnv directives during assh config build.
- Add parser and generator coverage and document defaults.SetEnv usage.

## Validation

- go test ./...
- go test -race ./...
- go vet ./...
- go build

Hooks and post-generation behavior are unchanged.
